### PR TITLE
fix: add livesys to build iso action

### DIFF
--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -73,6 +73,7 @@ jobs:
         id: build
         uses: ublue-os/titanoboa@main
         with:
+          livesys: "true"
           image-ref: ${{ steps.image_ref.outputs.image_ref }}:lts
           flatpaks-list: ${{ github.workspace }}/system_files/etc/ublue-os/system-flatpaks.list
           hook-post-rootfs: ${{ github.workspace }}/iso_files/configure_iso.sh


### PR DESCRIPTION
We need to add livesys so the downloaded iso actually works and gets a desktop session. 