### PR TITLE
chore: align with Bluefin LTS' configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 * @castrojo @imbev
+
+image-versions.yaml

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:best-practices"
+  ],
+
+  "rebaseWhen": "never",
+
+  "packageRules": [
+    {
+      "automerge": true,
+      "matchUpdateTypes": ["pin", "pinDigest"]
+    },
+    {
+      "enabled": false,
+      "matchUpdateTypes": ["digest", "pinDigest", "pin"],
+      "matchDepTypes": ["container"],
+      "matchFileNames": [".github/workflows/**.yaml", ".github/workflows/**.yml"]
+    },
+    {
+      "automerge": true,
+      "matchUpdateTypes": ["digest"],
+      "matchDepNames": ["quay.io/centos-bootc/centos-bootc"]
+    }
+  ]
+}

--- a/.github/workflows/build-dx-hwe.yml
+++ b/.github/workflows/build-dx-hwe.yml
@@ -1,9 +1,6 @@
 name: Build Aurora Helium DX HWE
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/build-dx.yml
+++ b/.github/workflows/build-dx.yml
@@ -1,9 +1,6 @@
 name: Build Aurora Helium DX
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/build-gdx.yml
+++ b/.github/workflows/build-gdx.yml
@@ -1,9 +1,6 @@
 name: Build Aurora Helium GDX
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/build-hwe.yml
+++ b/.github/workflows/build-hwe.yml
@@ -1,9 +1,6 @@
 name: Build Aurora Helium HWE
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/build-regular.yml
+++ b/.github/workflows/build-regular.yml
@@ -2,9 +2,6 @@
 name: Build Aurora Helium
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/Containerfile
+++ b/Containerfile
@@ -1,6 +1,5 @@
 ARG MAJOR_VERSION="${MAJOR_VERSION:-stream10}"
-FROM ghcr.io/ublue-os/config:latest@sha256:b7464c991152399a40ff5ce8991b3456c3bc0622cdbe51ca247cac8671b103ca AS config
-FROM quay.io/centos-bootc/centos-bootc@sha256:165e9103b7dffb108822488f5f631ea4ce73e75c76a8015aabf101afec1d9352
+FROM quay.io/centos-bootc/centos-bootc:$MAJOR_VERSION
 
 ARG ENABLE_DX="${ENABLE_DX:-0}"
 ARG ENABLE_HWE="${ENABLE_HWE:-0}"

--- a/image-versions.yaml
+++ b/image-versions.yaml
@@ -1,0 +1,5 @@
+images:
+  - name: centos-bootc
+    image: quay.io/centos-bootc/centos-bootc
+    tag: stream10
+    digest: sha256:165e9103b7dffb108822488f5f631ea4ce73e75c76a8015aabf101afec1d9352

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
-}


### PR DESCRIPTION
This PR makes the following changes:
1. Don't build on merge_group, pull_request _and_ push - only merge_group and pull_request
2. Don't pin docker images inside workflow files
3. Manage image digests inside a separate image-versions.yaml file (but don't use the version from this file yet)
4. Remove deprecated ublue-os/config image